### PR TITLE
Ignore libcxx setting

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -13,6 +13,9 @@ class Tinyxml2Conan(ConanFile):
     generators = "cmake"
     source_dir = "tinyxml2"
 
+    def configure(self):
+        del self.settings.compiler.libcxx
+
     def source(self):
         self.run("git clone https://github.com/leethomason/tinyxml2.git {0}".format(self.source_dir))
         self.run("cd {0} && git checkout {1}".format(self.source_dir, self.version))


### PR DESCRIPTION
Hi,

This PR removes the libcxx setting from the compiler settings since TinyXML2 does not use `std::string` and the output libraries are the same independently of this setting (note: I only checked that with GCC 5.4 with both static and dynamic libraries).

Otherwise, one could pass `pure_c = False` to the `builder.add_common_builds()` of `build.py` but that would double the number of Linux builds to generate the same package in the end.